### PR TITLE
Respect terminal color capabilities

### DIFF
--- a/src/Test/Tasty/Runners/Reporter.hs
+++ b/src/Test/Tasty/Runners/Reporter.hs
@@ -358,7 +358,8 @@ runGroup groupName children (GroupNames groupNames) =
     & TraversalT
 
 printSummary :: Summary -> Tasty.Time -> IO ()
-printSummary Summary {failures, errors, successes, skipped, hasOnly} duration =
+printSummary Summary {failures, errors, successes, skipped, hasOnly} duration = do
+  color <- hSupportsANSIColor stdout
   [ -- Title "TEST RUN ..."
     if hasOnly
       then
@@ -390,8 +391,9 @@ printSummary Summary {failures, errors, successes, skipped, hasOnly} duration =
       else "",
     styled [black] ("Failed:    " <> fromInt failedTestsTotal),
     "\n\n"
-  ]
-    & outputConcurrent . mconcat
+    ]
+    & mconcat
+    & if color then outputConcurrent else outputConcurrent . unstyled
   where
     failedTestsTotal = getSum (failures <> errors)
     skippedTestsTotal = getSum skipped


### PR DESCRIPTION
This pull request changes the output so that ANSI color codes are not printed on terminals that do not support them, as reported by [`System.Console.ANSI.hSupportsANSIColor`](https://hackage.haskell.org/package/ansi-terminal-0.10.3/docs/System-Console-ANSI.html#v:hSupportsANSIColor).