### PR TITLE
Relax version bounds of `tasty` and `ansi-terminal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1.2
+
+- Relax version bounds of `tasty` and `ansi-terminal` dependencies.
+
 # 0.1.0.0
 
 - Initial implementation.

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,3 @@
-{ pkgs ? import ./nixpkgs.nix }:
+let pkgs = import ./nixpkgs.nix;
 
-pkgs.haskellPackages.callCabal2nix "tasty-test-reporter" ./. { }
+in pkgs.haskellPackages.callCabal2nix "pretty-diff" ./. { }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -3,12 +3,12 @@ let
   #
   # Pick a release (e.g. nixpkgs-unstable) and open the `git-revision`
   # file. It will contain a revision hash. Copy and paste it below.
-  rev = "a8fc904c7c0d66f07d22bcb59a46d2bd72f8ddae";
+  rev = "0c59c1296b23abc25a6383ff26db2eeb17ad8a81";
   # Generate the SHA256 hash for this revision's tarball.
   #
   #   $ nix-prefetch-url --unpack --type sha256 \
   #   >   https://github.com/NixOS/nixpkgs/archive/${rev-defined-above}.tar.gz
-  sha256 = "142gzi01601c95hrwjizjc25qsmswldzw2zg6fvgw52lpag2w2qb";
+  sha256 = "03sifcpkc3prszaycd6snvpxam66phmj0b7m4723l5dmmsyq4bkw";
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     sha256 = sha256;

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: tasty-test-reporter
-version: 0.1.1.1
+version: 0.1.1.2
 synopsis: Producing JUnit-style XML test reports.
 description: Please see the README at <https://github.com/stoeffel/tasty-test-reporter>.
 author: Christoph Hermann

--- a/package.yaml
+++ b/package.yaml
@@ -14,7 +14,7 @@ extra-doc-files:
 - CHANGELOG.md
 library:
   dependencies:
-  - ansi-terminal >= 0.8 && < 0.11
+  - ansi-terminal >= 0.8 && < 0.12
   - base >= 4.10.1.0 && < 5
   - concurrent-output >= 1.10 && < 1.11
   - containers >= 0.5 && < 0.7
@@ -25,7 +25,7 @@ library:
   - safe-exceptions >= 0.1 && < 0.2
   - stm >= 2.4 && < 2.6
   - tagged >= 0.8 && < 0.9
-  - tasty >= 0.1 && < 1.3
+  - tasty >= 0.1 && < 1.4
   - text >= 1.2 && < 1.3
   exposed-modules:
   - Test.Tasty.Runners.Reporter
@@ -34,7 +34,7 @@ tests:
   spec:
     dependencies:
     - base
-    - tasty >= 1.1 && < 1.3
+    - tasty >= 1.1 && < 1.4
     - tasty-hunit
     - tasty-test-reporter
     main: Main.hs

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+name=$(grep name: < package.yaml | awk '{print $2}')
+version=$(grep version: < package.yaml | awk '{print $2}')
+bundle="$name-$version.tar.gz"
+
+# check changelog contains an entry for this version
+grep "^# $version$" < CHANGELOG.md
+
+hpack
+cabal sdist -o - > "$bundle"
+cabal upload --publish "$bundle"
+cabal upload -d --publish

--- a/shell.nix
+++ b/shell.nix
@@ -1,19 +1,11 @@
-{ pkgs ? import ./nixpkgs.nix }:
-
-let
-  ormolu = pkgs.haskellPackages.callCabal2nix "ormolu" (pkgs.fetchFromGitHub {
-    owner = "tweag";
-    repo = "ormolu";
-    rev = "3abadaefa5e190ff346f9aeb309465ac890495c2";
-    sha256 = "0vqrb12bsp1dczff3i5pajzhjwz035rxg8vznrgj5p6j7mb2vcnd";
-  }) { };
+let pkgs = import ./nixpkgs.nix;
 
 in pkgs.haskellPackages.shellFor {
-  packages = p: [ (pkgs.callPackage ./default.nix { }) ];
+  packages = p: [ (import ./default.nix) ];
   buildInputs = [
     pkgs.cabal-install
     pkgs.haskellPackages.ghcid
     pkgs.haskellPackages.hpack
-    ormolu
+    pkgs.ormolu
   ];
 }


### PR DESCRIPTION
This makes us compatible with latest versions of all dependencies, allowing us to be on stackage.

Version has already been published: https://hackage.haskell.org/package/tasty-test-reporter-0.1.1.2