### PR TITLE
Bump the upperbound for text to 2.1

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,7 @@ library:
   - stm >= 2.4 && < 2.6
   - tagged >= 0.8 && < 0.9
   - tasty >= 0.1 && < 1.5
-  - text >= 1.2 && < 1.3
+  - text >= 1.2 && < 2.1
   exposed-modules:
   - Test.Tasty.Runners.Reporter
   source-dirs: src


### PR DESCRIPTION
This pull request tries to resolve #7.

I have tested that the package works well with text-2.0.1, and bumped the upperbound for text to 2.1.

I would appreciate it if you could upload an revision to Hackage and bring it to nightly Haskell.
