### PR TITLE
Update dependencies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -14,19 +14,19 @@ extra-doc-files:
 - CHANGELOG.md
 library:
   dependencies:
-  - ansi-terminal >= 0.8 && < 0.12
+  - ansi-terminal >= 0.8 && < 1.1
   - base >= 4.10.1.0 && < 5
   - concurrent-output >= 1.10 && < 1.11
   - containers >= 0.5 && < 0.7
   - directory >= 1.3 && < 1.4
   - filepath >= 1.4 && < 1.5
   - junit-xml >= 0.1 && < 0.2
-  - mtl >= 2.2 && < 2.3
+  - mtl >= 2.2 && < 2.4
   - safe-exceptions >= 0.1 && < 0.2
   - stm >= 2.4 && < 2.6
   - tagged >= 0.8 && < 0.9
   - tasty >= 0.1 && < 1.5
-  - text >= 1.2 && < 1.3
+  - text >= 1.2 && < 2.2
   exposed-modules:
   - Test.Tasty.Runners.Reporter
   source-dirs: src


### PR DESCRIPTION
Old `mtl` dependency was causing problems in one of our projects, so update that and all other relevant deps.

Builds with these deps and `ghc-9.6`.

Would really appreciate a new version on Hackage or updated metadata on Hackage.