### PR TITLE
Bump tasty to 1.5

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ library:
   - safe-exceptions >= 0.1 && < 0.2
   - stm >= 2.4 && < 2.6
   - tagged >= 0.8 && < 0.9
-  - tasty >= 0.1 && < 1.5
+  - tasty >= 0.1 && < 1.6
   - text >= 1.2 && < 2.2
   exposed-modules:
   - Test.Tasty.Runners.Reporter

--- a/src/Test/Tasty/Runners/Reporter.hs
+++ b/src/Test/Tasty/Runners/Reporter.hs
@@ -215,7 +215,9 @@ runner consolePrintPolicy options testTree path statusMap = withConcurrentOutput
     Tasty.foldTestTree
       Tasty.trivialFold
         { Tasty.foldSingle = runTest consolePrintPolicy statusMap,
-#if MIN_VERSION_tasty(1,4,0)
+#if MIN_VERSION_tasty(1,5,0)
+          Tasty.foldGroup = \_ groupName children -> runGroup groupName (mconcat children)
+#elif MIN_VERSION_tasty(1,4,0)
           Tasty.foldGroup = \_ -> runGroup
 #else
           Tasty.foldGroup = runGroup

--- a/tasty-test-reporter.cabal
+++ b/tasty-test-reporter.cabal
@@ -1,0 +1,64 @@
+cabal-version: 1.18
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           tasty-test-reporter
+version:        0.1.1.4
+synopsis:       Producing JUnit-style XML test reports.
+description:    Please see the README at <https://github.com/stoeffel/tasty-test-reporter>.
+category:       Testing
+homepage:       https://github.com/stoeffel/tasty-test-reporter#readme
+bug-reports:    https://github.com/stoeffel/tasty-test-reporter/issues
+author:         Christoph Hermann
+maintainer:     schtoeffel@gmail.com
+copyright:      2020 Christoph Hermann
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/stoeffel/tasty-test-reporter
+
+library
+  exposed-modules:
+      Test.Tasty.Runners.Reporter
+  other-modules:
+      Test.Console.Color
+      Paths_tasty_test_reporter
+  hs-source-dirs:
+      src
+  build-depends:
+      ansi-terminal >=0.8 && <1.1
+    , base >=4.10.1.0 && <5
+    , concurrent-output ==1.10.*
+    , containers >=0.5 && <0.7
+    , directory ==1.3.*
+    , filepath ==1.4.*
+    , junit-xml ==0.1.*
+    , mtl >=2.2 && <2.4
+    , safe-exceptions ==0.1.*
+    , stm >=2.4 && <2.6
+    , tagged ==0.8.*
+    , tasty >=0.1 && <1.6
+    , text >=1.2 && <2.2
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_tasty_test_reporter
+  hs-source-dirs:
+      test
+  build-depends:
+      base
+    , tasty
+    , tasty-hunit
+    , tasty-test-reporter
+  default-language: Haskell2010


### PR DESCRIPTION
This fixes the error seen in #11 and is based on the tasty CHANGELOG suggestion:

> * foldGroup now takes `[b]` instead of `b` as its last argument to allow for custom fold strategies. This is a backwards incompatible change, but you can get the old behavior by applying `mconcat` ([#364](https://github.com/UnkindPartition/tasty/issues/364)).
