### PR TITLE
Upgrade dependency bounds, enable tasty-1.5.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-tasty-test-reporter.cabal
 dist-newstyle
 result
 build

--- a/package.yaml
+++ b/package.yaml
@@ -14,18 +14,18 @@ extra-doc-files:
 - CHANGELOG.md
 library:
   dependencies:
-  - ansi-terminal >= 0.8 && < 1.1
+  - ansi-terminal >= 0.8 && < 1.2
   - base >= 4.10.1.0 && < 5
   - concurrent-output >= 1.10 && < 1.11
-  - containers >= 0.5 && < 0.7
+  - containers >= 0.5 && < 0.8
   - directory >= 1.3 && < 1.4
-  - filepath >= 1.4 && < 1.5
+  - filepath >= 1.4 && < 1.6
   - junit-xml >= 0.1 && < 0.2
   - mtl >= 2.2 && < 2.4
   - safe-exceptions >= 0.1 && < 0.2
   - stm >= 2.4 && < 2.6
   - tagged >= 0.8 && < 0.9
-  - tasty >= 0.1 && < 1.5
+  - tasty >= 0.1 && < 1.6
   - text >= 1.2 && < 2.2
   exposed-modules:
   - Test.Tasty.Runners.Reporter

--- a/src/Test/Tasty/Runners/Reporter.hs
+++ b/src/Test/Tasty/Runners/Reporter.hs
@@ -215,7 +215,9 @@ runner consolePrintPolicy options testTree path statusMap = withConcurrentOutput
     Tasty.foldTestTree
       Tasty.trivialFold
         { Tasty.foldSingle = runTest consolePrintPolicy statusMap,
-#if MIN_VERSION_tasty(1,4,0)
+#if MIN_VERSION_tasty(1,5,0)
+          Tasty.foldGroup = \_ groupName children -> runGroup groupName (mconcat children)
+#elif MIN_VERSION_tasty(1,4,0)
           Tasty.foldGroup = \_ -> runGroup
 #else
           Tasty.foldGroup = runGroup

--- a/tasty-test-reporter.cabal
+++ b/tasty-test-reporter.cabal
@@ -1,0 +1,64 @@
+cabal-version: 1.18
+
+-- This file has been generated from package.yaml by hpack version 0.37.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           tasty-test-reporter
+version:        0.1.1.4
+synopsis:       Producing JUnit-style XML test reports.
+description:    Please see the README at <https://github.com/stoeffel/tasty-test-reporter>.
+category:       Testing
+homepage:       https://github.com/stoeffel/tasty-test-reporter#readme
+bug-reports:    https://github.com/stoeffel/tasty-test-reporter/issues
+author:         Christoph Hermann
+maintainer:     schtoeffel@gmail.com
+copyright:      2020 Christoph Hermann
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/stoeffel/tasty-test-reporter
+
+library
+  exposed-modules:
+      Test.Tasty.Runners.Reporter
+  other-modules:
+      Test.Console.Color
+      Paths_tasty_test_reporter
+  hs-source-dirs:
+      src
+  build-depends:
+      ansi-terminal >=0.8 && <1.2
+    , base >=4.10.1.0 && <5
+    , concurrent-output ==1.10.*
+    , containers >=0.5 && <0.8
+    , directory ==1.3.*
+    , filepath >=1.4 && <1.6
+    , junit-xml ==0.1.*
+    , mtl >=2.2 && <2.4
+    , safe-exceptions ==0.1.*
+    , stm >=2.4 && <2.6
+    , tagged ==0.8.*
+    , tasty >=0.1 && <1.6
+    , text >=1.2 && <2.2
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_tasty_test_reporter
+  hs-source-dirs:
+      test
+  build-depends:
+      base
+    , tasty
+    , tasty-hunit
+    , tasty-test-reporter
+  default-language: Haskell2010


### PR DESCRIPTION
This is a new variant of https://github.com/stoeffel/tasty-test-reporter/pull/12 which ~does not add a cabal file and~ also bumps a few more upper bounds to suit stackage LTS-23.9 (`ghc-9.8.4`).

Would appreciate if you could upload a new revision on hackage, too, but it already helps if this gets onto master here.

@stoeffel @jwoudenberg This is a nice and useful tool that we would not want to miss in our build, thanks for putting it together!

